### PR TITLE
🌟 (Built-in commands) Auto inject -h,--help / -v,--version

### DIFF
--- a/src/Cmdlet.js
+++ b/src/Cmdlet.js
@@ -442,17 +442,6 @@ class Cmdlet {
             missing: 0
         };
 
-        if (this.atRoot()) {
-            this.pkgConfig = File.from(require.main.filename).upTo('package.json').load();
-            // This is to avoid examples loading the main project package.json info
-            if (this.pkgConfig.name === 'switchit') {
-                this.pkgConfig = {};
-            }
-            if (!this.pkgConfig.name) {
-                this.pkgConfig.name = this.constructor.name.toLowerCase();
-            }
-        }
-
         return args.pull().then(arg => {
             // While we have arguments, try to process them
             if (arg !== null) {
@@ -529,6 +518,18 @@ class Cmdlet {
         var params = me.params;
 
         args.ownerPush(me);
+
+        if (this.atRoot()) { 
+            this.rootDir = File.from(require.main.filename).upTo('package.json').parent; 
+            this.pkgConfig = this.rootDir.join('package.json').load(); 
+            // This is to avoid examples loading the main project package.json info 
+            if (this.pkgConfig.name === 'switchit') { 
+                this.pkgConfig = {}; 
+            } 
+            if (!this.pkgConfig.name) { 
+                this.pkgConfig.name = this.constructor.name.toLowerCase(); 
+            } 
+        }
 
         return Util.finally(me.configure(args).then(() => {
             me.applyDefaults(params);

--- a/src/commands/Version.js
+++ b/src/commands/Version.js
@@ -10,9 +10,12 @@ class Version extends Command {
 
     execute() {
         let pkg = this.root().pkgConfig;
-        let version = (pkg && pkg.version) || 'unknown';
-
-        console.log(`${chalk.yellow(pkg.name)} version: ${chalk.green(version)}`);
+        if (pkg && pkg.version) { 
+            console.log(pkg.version); 
+        } else { 
+            // No package.json? 
+            throw new Error(`unknown (can't find package.json)`); 
+        } 
     }
 }
 

--- a/test-files/help/html.html
+++ b/test-files/help/html.html
@@ -3,8 +3,8 @@
 <h2 id="usage">Usage</h2>
 <p>  <code>bar [options] [command]</code> Runs [command]</p>
 <h2 id="options-">Options:</h2>
-<p>  · <code>--rst</code>                   <em>(string)</em> jumps over the lazy dog.
-                              <em>(default: test)</em>                  </p>
+<p>  · <code>-h</code>, <code>--help</code>            <em>(boolean)</em> Show help<br>                              <em>(default: false)</em><br>  · <code>--rst</code>                   <em>(string)</em> jumps over the lazy dog.
+                              <em>(default: test)</em><br>  · <code>-v</code>, <code>--version</code>         <em>(boolean)</em> Show version<br>                              <em>(default: false)</em>                 </p>
 <h2 id="commands-">Commands:</h2>
 <p>  · <code>uvw</code>                     The quick<br>                              <em>(also known as: xyz)</em></p>
 <p>Run <code>bar help [command]</code> for more information on a command.</p>

--- a/test-files/help/markdown.md
+++ b/test-files/help/markdown.md
@@ -4,8 +4,12 @@
   `bar [options] [command]` Runs [command]
 
 ## Options:
+  · `-h`, `--help`            _(boolean)_ Show help
+                              _(default: false)_
   · `--rst`                   _(string)_ jumps over the lazy dog.
                               _(default: test)_
+  · `-v`, `--version`         _(boolean)_ Show version
+                              _(default: false)_
 
 ## Commands:
   · `uvw`                     The quick

--- a/test-files/help/nested.txt
+++ b/test-files/help/nested.txt
@@ -8,8 +8,12 @@ Usage
 
 Options:
 
+  · -h, --help            (boolean) Show help
+                              (default: false)
   · --rst                   (string) jumps over the lazy dog.
                               (default: test)
+  · -v, --version         (boolean) Show version
+                              (default: false)
 
 Commands:
 

--- a/test/unit/Container.js
+++ b/test/unit/Container.js
@@ -519,7 +519,7 @@ describe('Container', function() {
                 return foo.run([]);
             }).then(out => {
                 console.log(out);
-                expect(out).to.contain('Usage\n\n  foo [command]');
+                expect(out).to.contain('Usage\n\n  foo [options] [command] Runs [command]');
             }));
         });
     });

--- a/test/unit/Help.js
+++ b/test/unit/Help.js
@@ -244,7 +244,7 @@ describe('Help', function () {
             return def.run(['help', '-color']);
         }).then(out => {
             expect(out).to.contain('def                     Run command abc');
-            expect(out).to.contain('def [command]');
+            expect(out).to.contain('def [options] [command] Runs [command]');
         }));
     });
 
@@ -357,29 +357,6 @@ describe('Help', function () {
         }));
     });
 
-    it('should not show "Options" if all switches are private', function (done) {
-        class Abc extends Container {}
-
-        Abc.define({
-            switches: {
-                foo: {
-                    value: false,
-                    private: true
-                }
-            },
-            commands: {
-                help: Help
-            }
-        });
-
-        var abc = new Abc();
-
-        Util.resolves(done, Util.capturesStdout(() => {
-            return abc.run(['help', '-color']);
-        }).then(out => {
-            expect(out).not.to.contain("Options:");
-        }));
-    });
     it('should provide a way to display all elements (private and special)', function (done) {
         class Abc extends Command {}
         class Def extends Command {}


### PR DESCRIPTION
This feature enables auto-injection for "help" and "version" as private commands, which can also be invoked with the -h and -v switches (respectively).

Additionally, following the common approach of cli apps, the version command will only display the version.